### PR TITLE
replaced AnyAsync by AllAsync for barcode unicity validation

### DIFF
--- a/Infrastructure.Persistence/Repositories/ProductRepositoryAsync.cs
+++ b/Infrastructure.Persistence/Repositories/ProductRepositoryAsync.cs
@@ -22,7 +22,7 @@ namespace Infrastructure.Persistence.Repositories
         public Task<bool> IsUniqueBarcodeAsync(string barcode)
         {
             return _products
-                .AnyAsync(p => p.Barcode == barcode);
+                .AllAsync(p => p.Barcode != barcode);
         }
     }
 }


### PR DESCRIPTION
My bad ! I used the wrong DbSet method to check barcode unicity here. 
DbSet.AllAsync should be used in this case.