### PR TITLE
Fix build error for visual studio 

### DIFF
--- a/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>1.1.0</Version>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 <ItemGroup>
   <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>1.1.0</Version>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -8,6 +8,7 @@
     <RepositoryType>Public</RepositoryType>
     <PackageProjectUrl>https://www.codewithmukesh.com/blog/aspnet-core-webapi-clean-architecture/</PackageProjectUrl>
     <Version>1.1.0</Version>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
I was getting following error to build the application after clone. visual studio professional 2019 version 16.3.9. According to https://stackoverflow.com/questions/58624146/feature-using-declarations-is-not-available-in-c-sharp-7-3-please-use-languag specifying the `LangVersion` as latest is the fix. Specifying the `LangVersion` has no other issues. So it can be considered as safe changes. 
![visual-studio-build-error](https://user-images.githubusercontent.com/8801513/96373909-39a55a00-1191-11eb-91a7-f46c0baedb1e.png)
