### PR TITLE
updated generic repositories to factor in non integer id's

### DIFF
--- a/Application/Interfaces/IGenericRepositoryAsync.cs
+++ b/Application/Interfaces/IGenericRepositoryAsync.cs
@@ -5,13 +5,18 @@ using System.Threading.Tasks;
 
 namespace Application.Interfaces
 {
-    public interface IGenericRepositoryAsync<T> where T : class
+    public interface IGenericRepositoryAsync<T,in TId> where T : class
     {
-        Task<T> GetByIdAsync(int id);
+        Task<T> GetByIdAsync(TId id);
         Task<IReadOnlyList<T>> GetAllAsync();
         Task<IReadOnlyList<T>> GetPagedReponseAsync(int pageNumber, int pageSize);
         Task<T> AddAsync(T entity);
         Task UpdateAsync(T entity);
         Task DeleteAsync(T entity);
+    }
+
+    public interface IGenericRepositoryAsync<T> : IGenericRepositoryAsync<T, int> where T : class
+    {
+
     }
 }

--- a/Domain/Common/AuditableBaseEntity.cs
+++ b/Domain/Common/AuditableBaseEntity.cs
@@ -1,15 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 
 namespace Domain.Common
 {
-    public abstract class AuditableBaseEntity
+    public abstract class AuditableBaseEntity<T> : BaseEntity<T>, IAuditableEntity
     {
-        public virtual int Id { get; set; }
-        public string CreatedBy { get; set; }
+        [StringLength(40)] public string CreatedBy { get; set; }
         public DateTime Created { get; set; }
-        public string LastModifiedBy { get; set; }
+        [StringLength(40)] public string LastModifiedBy { get; set; }
         public DateTime? LastModified { get; set; }
+    } 
+    
+    
+    public abstract class AuditableBaseEntity:AuditableBaseEntity<int>
+    {
+        
     }
 }

--- a/Domain/Common/BaseEntity.cs
+++ b/Domain/Common/BaseEntity.cs
@@ -1,10 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 
 namespace Domain.Common
 {
-    public abstract class BaseEntity
+    public abstract class BaseEntity<T>:IEntity<T>
+    {
+        [Key] public virtual T Id { get; set; }
+    }
+
+    public abstract class BaseEntity:IEntity<int>
     {
         public virtual int Id { get; set; }
     }

--- a/Domain/Common/IAuditableEntity.cs
+++ b/Domain/Common/IAuditableEntity.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Domain.Common
+{
+    public interface IAuditableEntity<T> : IAuditableEntity
+    {
+        public T Id { get; set; }
+    }
+
+    public interface IAuditableEntity
+    {
+        public string CreatedBy { get; set; }
+        public DateTime Created { get; set; }
+        public string LastModifiedBy { get; set; }
+        public DateTime? LastModified { get; set; }
+    }
+}

--- a/Domain/Common/IEntity.cs
+++ b/Domain/Common/IEntity.cs
@@ -1,0 +1,7 @@
+﻿namespace Domain.Common
+{
+    public interface IEntity<T> 
+    {
+        public T Id { get; set; }
+    }
+}

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -5,4 +5,8 @@
     <Version>1.1.0</Version>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Infrastructure.Persistence/Contexts/ApplicationDbContext.cs
+++ b/Infrastructure.Persistence/Contexts/ApplicationDbContext.cs
@@ -27,7 +27,7 @@ namespace Infrastructure.Persistence.Contexts
 
         public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = new CancellationToken())
         {
-            foreach (var entry in ChangeTracker.Entries<AuditableBaseEntity>())
+            foreach (var entry in ChangeTracker.Entries<IAuditableEntity>())
             {
                 switch (entry.State)
                 {

--- a/Infrastructure.Persistence/Repositories/GenericRepositoryAsync.cs
+++ b/Infrastructure.Persistence/Repositories/GenericRepositoryAsync.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Infrastructure.Persistence.Repository
 {
-    public class GenericRepositoryAsync<T> : IGenericRepositoryAsync<T> where T : class
+    public class GenericRepositoryAsync<T, TId> : IGenericRepositoryAsync<T,TId> where T : class
     {
         private readonly ApplicationDbContext _dbContext;
 
@@ -18,7 +18,7 @@ namespace Infrastructure.Persistence.Repository
             _dbContext = dbContext;
         }
 
-        public virtual async Task<T> GetByIdAsync(int id)
+        public virtual async Task<T> GetByIdAsync(TId id)
         {
             return await _dbContext.Set<T>().FindAsync(id);
         }
@@ -57,6 +57,15 @@ namespace Infrastructure.Persistence.Repository
             return await _dbContext
                  .Set<T>()
                  .ToListAsync();
+        }
+
+       
+    }
+
+    public class GenericRepositoryAsync<T> : GenericRepositoryAsync<T, int>, IGenericRepositoryAsync<T> where T : class
+    {
+        public GenericRepositoryAsync(ApplicationDbContext dbContext) : base(dbContext)
+        {
         }
     }
 }

--- a/Infrastructure.Persistence/ServiceRegistration.cs
+++ b/Infrastructure.Persistence/ServiceRegistration.cs
@@ -30,6 +30,7 @@ namespace Infrastructure.Persistence
             }
             #region Repositories
             services.AddTransient(typeof(IGenericRepositoryAsync<>), typeof(GenericRepositoryAsync<>));
+            services.AddTransient(typeof(IGenericRepositoryAsync<,>), typeof(GenericRepositoryAsync<,>));
             services.AddTransient<IProductRepositoryAsync, ProductRepositoryAsync>();
             #endregion
         }


### PR DESCRIPTION
- updated generic repositories to factor in non integer id's

- added iauditable entity as base for all auditable entities.

- Iauditable entiity can then be used in the saved changes method to get all entries

```
 public interface IGenericRepositoryAsync<T,in TId> where T : class
    {
        Task<T> GetByIdAsync(TId id);
        Task<IReadOnlyList<T>> GetAllAsync();
        Task<IReadOnlyList<T>> GetPagedReponseAsync(int pageNumber, int pageSize);
        Task<T> AddAsync(T entity);
        Task UpdateAsync(T entity);
        Task DeleteAsync(T entity);
    }

    public interface IGenericRepositoryAsync<T> : IGenericRepositoryAsync<T, int> where T : class
    {

    }
```

```
  services.AddTransient(typeof(IGenericRepositoryAsync<,>), typeof(GenericRepositoryAsync<,>));
```