### PR TITLE
Check if roles already exists before seeding

### DIFF
--- a/Infrastructure.Identity/Seeds/DefaultRoles.cs
+++ b/Infrastructure.Identity/Seeds/DefaultRoles.cs
@@ -12,11 +12,15 @@ namespace Infrastructure.Identity.Seeds
     {
         public static async Task SeedAsync(UserManager<ApplicationUser> userManager, RoleManager<IdentityRole> roleManager)
         {
+            //Check if Roles already Exists Before Seeding otherwise we get warning everytime project starts => DuplicateRoleName.
+            if(!roleManager.Roles.Any())
+            {
             //Seed Roles
             await roleManager.CreateAsync(new IdentityRole(Roles.SuperAdmin.ToString()));
             await roleManager.CreateAsync(new IdentityRole(Roles.Admin.ToString()));
             await roleManager.CreateAsync(new IdentityRole(Roles.Moderator.ToString()));
             await roleManager.CreateAsync(new IdentityRole(Roles.Basic.ToString()));
+            }
         }
     }
 }


### PR DESCRIPTION
Checked if Roles already Exists Before Seeding otherwise we get warning everytime project starts => DuplicateRoleName.